### PR TITLE
Add a cron job GitHub Action to run the vsdiff script every hour

### DIFF
--- a/.github/workflows/update-vsdiff.yml
+++ b/.github/workflows/update-vsdiff.yml
@@ -1,6 +1,7 @@
 name: Update vsdiff
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 * * * *"
 

--- a/.github/workflows/update-vsdiff.yml
+++ b/.github/workflows/update-vsdiff.yml
@@ -2,6 +2,8 @@ name: Update vsdiff
 
 on:
   workflow_dispatch:
+  repository_dispatch:
+    types: [update]
   schedule:
     - cron: "0 * * * *"
 

--- a/.github/workflows/update-vsdiff.yml
+++ b/.github/workflows/update-vsdiff.yml
@@ -1,0 +1,31 @@
+name: Update vsdiff
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  update-vsdiff:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Config git user
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+    - name: Run update script
+      run: ./vsdiff
+
+    - name: Commit changes
+      run: |
+        git commit -am 'Update vsdiff files'
+
+    - name: Push changes
+      run: |
+        git push


### PR DESCRIPTION
Add a GitHub Actions workflow to run the vsdiff script every hour, commit the updated txt files, and push to the main branch.

* **Workflow file**: Add `.github/workflows/update-vsdiff.yml` to define the GitHub Actions workflow.
* **Schedule**: Set the workflow to run every hour using a cron job.
* **Steps**:
  - Checkout the repository using `actions/checkout@v4`.
  - Configure git user for committing changes.
  - Run the `vsdiff` script.
  - Commit the changes with the message 'Update vsdiff files'.
  - Push the changes to the main branch.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/btwiuse/vsdiff/pull/2?shareId=54dcb1c7-db9c-463a-822e-828258f9b28c).