### PR TITLE
Add a new VSCodium target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ all:
 	./vsdiff "vscode" "reh-web" "stable"
 	./vsdiff "vscode" "reh-web" "insider"
 	./vsdiff "vscode" "reh-web" "exploration"
+	./vsdiff "vscodium" "web"
+	./vsdiff "vscodium" "reh"
+	./vsdiff "vscodium" "reh-web"
 	./compare *_reh_* > reh.diff.csv
 	./compare *_web_* > web.diff.csv
 	./compare *_reh-web_* > reh-web.diff.csv

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ all:
 	./vsdiff "vscode" "reh-web" "stable"
 	./vsdiff "vscode" "reh-web" "insider"
 	./vsdiff "vscode" "reh-web" "exploration"
-	./vsdiff "vscodium" "web"
 	./vsdiff "vscodium" "reh"
 	./vsdiff "vscodium" "reh-web"
 	./compare *_reh_* > reh.diff.csv

--- a/vsdiff
+++ b/vsdiff
@@ -24,35 +24,32 @@ update_vsdiff() {
     if [[ "$type" == "web" ]]; then
       URL="https://update.code.visualstudio.com/api/update/web-standalone/$quality/latest"
       JSON="$(curl -sL $URL | jq .)"
-      NAME="$(jq -r .name <<< "$JSON")"
+      TAG="$(jq -r .name <<< "$JSON")"
       DOWNLOAD_URL="$(jq -r .url <<< "$JSON")"
-      OUTPUT_FILE="vscode_web_$NAME.txt"
+      OUTPUT_FILE="vscode_web_$TAG.txt"
     elif [[ "$type" == "reh" ]]; then
       URL="https://update.code.visualstudio.com/api/update/server-linux-x64/$quality/latest"
       JSON="$(curl -sL $URL | jq .)"
-      NAME="$(jq -r .name <<< "$JSON")"
+      TAG="$(jq -r .name <<< "$JSON")"
       DOWNLOAD_URL="$(jq -r .url <<< "$JSON")"
-      OUTPUT_FILE="vscode_reh_$NAME.txt"
+      OUTPUT_FILE="vscode_reh_$TAG.txt"
     elif [[ "$type" == "reh-web" ]]; then
       URL="https://update.code.visualstudio.com/api/update/server-linux-x64-web/$quality/latest"
       JSON="$(curl -sL $URL | jq .)"
-      NAME="$(jq -r .name <<< "$JSON")"
+      TAG="$(jq -r .name <<< "$JSON")"
       DOWNLOAD_URL="$(jq -r .url <<< "$JSON")"
-      OUTPUT_FILE="vscode_reh-web_$NAME.txt"
+      OUTPUT_FILE="vscode_reh-web_$TAG.txt"
     else
       echo "Invalid type for vscode: $type"
       return 1
     fi
   elif [[ "$product" == "vscodium" ]]; then
     TAG="$(curl -sI https://github.com/VSCodium/vscodium/releases/latest | grep location: | rev | cut -d / -f 1 | rev | tr -d '[:space:]')"
-    if [[ "$type" == "web" ]]; then
-      DOWNLOAD_URL="https://github.com/VSCodium/vscodium/releases/download/$TAG/VSCodium-linux-x64-$TAG.tar.gz"
-      OUTPUT_FILE="vscodium_web_$TAG.txt"
-    elif [[ "$type" == "reh" ]]; then
-      DOWNLOAD_URL="https://github.com/VSCodium/vscodium/releases/download/$TAG/VSCodium-linux-x64-$TAG.tar.gz"
+    if [[ "$type" == "reh" ]]; then
+      DOWNLOAD_URL="https://github.com/VSCodium/vscodium/releases/download/$TAG/vscodium-reh-linux-x64-$TAG.tar.gz"
       OUTPUT_FILE="vscodium_reh_$TAG.txt"
     elif [[ "$type" == "reh-web" ]]; then
-      DOWNLOAD_URL="https://github.com/VSCodium/vscodium/releases/download/$TAG/VSCodium-linux-x64-$TAG.tar.gz"
+      DOWNLOAD_URL="https://github.com/VSCodium/vscodium/releases/download/$TAG/vscodium-reh-web-linux-x64-$TAG.tar.gz"
       OUTPUT_FILE="vscodium_reh-web_$TAG.txt"
     else
       echo "Invalid type for vscodium: $type"
@@ -63,7 +60,7 @@ update_vsdiff() {
     return 1
   fi
 
-  echo "$product-$type: $NAME"
+  echo "$product-$type: $TAG"
   echo "$DOWNLOAD_URL"
   curl -#L "$DOWNLOAD_URL" | tar tz | sed \
     -e '/\/$/d' \

--- a/vsdiff
+++ b/vsdiff
@@ -43,6 +43,21 @@ update_vsdiff() {
       echo "Invalid type for vscode: $type"
       return 1
     fi
+  elif [[ "$product" == "vscodium" ]]; then
+    TAG="$(curl -sI https://github.com/VSCodium/vscodium/releases/latest | grep location: | rev | cut -d / -f 1 | rev | tr -d '[:space:]')"
+    if [[ "$type" == "web" ]]; then
+      DOWNLOAD_URL="https://github.com/VSCodium/vscodium/releases/download/$TAG/VSCodium-linux-x64-$TAG.tar.gz"
+      OUTPUT_FILE="vscodium_web_$TAG.txt"
+    elif [[ "$type" == "reh" ]]; then
+      DOWNLOAD_URL="https://github.com/VSCodium/vscodium/releases/download/$TAG/VSCodium-linux-x64-$TAG.tar.gz"
+      OUTPUT_FILE="vscodium_reh_$TAG.txt"
+    elif [[ "$type" == "reh-web" ]]; then
+      DOWNLOAD_URL="https://github.com/VSCodium/vscodium/releases/download/$TAG/VSCodium-linux-x64-$TAG.tar.gz"
+      OUTPUT_FILE="vscodium_reh-web_$TAG.txt"
+    else
+      echo "Invalid type for vscodium: $type"
+      return 1
+    fi
   else
     echo "Invalid product: $product"
     return 1


### PR DESCRIPTION
Add a new target for VSCodium.

* **Makefile**
  - Add targets for VSCodium: `./vsdiff "vscodium" "web"`, `./vsdiff "vscodium" "reh"`, and `./vsdiff "vscodium" "reh-web"`.

* **vsdiff**
  - Add logic to handle VSCodium similar to `codigo` and `vscode`.
  - Add `vscodium` product with `web`, `reh`, and `reh-web` types.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/btwiuse/vsdiff/pull/4?shareId=277c3fdb-a0fe-47ef-87c2-75f3280906a6).